### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.1",
     "symfony/http-foundation": "^4.4 || ^5.4 || ^6.1",
     "symfony/http-kernel": "^4.4 || ^5.4 || ^6.1",
-    "symfony/polyfill-php80": "^1.23",
     "twig/twig": "^2.12.5 || ^3.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: ^8.1`, so the polyfill requirement doesn't seem necessary anymore?